### PR TITLE
Swift-MesonLSP.spec: Fix versioning, license

### DIFF
--- a/Swift-MesonLSP.spec
+++ b/Swift-MesonLSP.spec
@@ -2,13 +2,13 @@
 %undefine _auto_set_build_flags
 
 Name:           Swift-MesonLSP
-Version:        0.0.33
-Release:        3.0.6
+Version:        3.0.6
+Release:        0.1
 Summary:        Meson language server
 ExclusiveArch:  x86_64
 
-License:        GPL
-Source0:        https://github.com/JCWasmx86/Swift-MesonLSP/archive/refs/tags/v3.0.6.tar.gz
+License:        GPL-3.0-or-later
+Source0:        https://github.com/JCWasmx86/Swift-MesonLSP/archive/refs/tags/v%{version}.tar.gz
 
 Requires:       bash
 BuildRequires:  swift-lang
@@ -19,13 +19,12 @@ BuildRequires:  git
 A meson language server
 
 %prep
-%setup -q -n Swift-MesonLSP-3.0.6
-
+%setup -q -n Swift-MesonLSP-%{version}
 
 %build
 git clone https://github.com/JCWasmx86/Swift-MesonLSP
 cd Swift-MesonLSP
-git checkout v3.0.6
+git checkout v%{version}
 swift build -c release --static-swift-stdlib -Xswiftc -g
 
 %install
@@ -37,6 +36,11 @@ cp Swift-MesonLSP/.build/release/Swift-MesonLSP $RPM_BUILD_ROOT/%{_bindir}
 %{_bindir}/Swift-MesonLSP
 
 %changelog
+* Mon Oct 24 2023 FeRD (Frank Dana) <ferdnyc@gmail.com> - 3.0.6-0.1
+- Fix versioning
+- Use SPDX license tag
+- Use %%{version} for easier specfile maintenance
+
 * Mon Oct 24 2023 JCWasmx86 <JCWasmx86@t-online.de> - 0.0.34
 - Bump to v3.0.6
 * Mon Oct 23 2023 JCWasmx86 <JCWasmx86@t-online.de> - 0.0.33


### PR DESCRIPTION
This PR makes some tweaks to the RPM `.spec` file to match Fedora guidelines/norms, and for easier maintenance.

- Swap `Version:` and `Release:` fields
- Use more specific SPDX license tag in `License` field
- Use `%{version}` throughout rest of spec file, to avoid repeatedly hardcoding version numbers

The `Release:` field should be reset on each new upstream version — package `3.0.6-0.1` would be followed by `3.0.6-0.2`, if a new build has to be made, then `3.0.6-0.3`, and so on. Then, when 3.0.7 is released, it gets packaged as `3.0.7-0.1` in COPR. You get the idea.

(The main/only reason to use `0.x` release numbers in COPR is to avoid release-numbering conflicts. If the package gets submitted to the Fedora package collection, the first Fedora release would typically be the `Release: 1` build for that version.)

Fixes #19 
