### PR TITLE
Allow using system-provided Google Benchmark

### DIFF
--- a/src/benchmarks/meson.build
+++ b/src/benchmarks/meson.build
@@ -1,10 +1,8 @@
 if not get_option('benchmarks')
     subdir_done()
 endif
-benchmark_dep = subproject('google-benchmark').get_variable(
-    'google_benchmark_dep',
-)
-if not benchmark_dep.found() or not get_option('benchmarks')
+benchmark_dep = dependency('benchmark', version: '>= 1.7.1', allow_fallback: true, required: false)
+if not benchmark_dep.found()
     subdir_done()
 endif
 executable(


### PR DESCRIPTION
The spec file installs system Google Benchmark and devel files, but they are not used because the meson setup does not ask for it. I set the minimum based on the version in the wrap file.

Also, fix skip by setting `required:false`.