### PR TITLE
Improve spec file

### DIFF
--- a/mesonlsp.spec
+++ b/mesonlsp.spec
@@ -9,29 +9,24 @@ ExclusiveArch:  x86_64
 License:        GPL-3.0-or-later
 Source0:        https://github.com/JCWasmx86/mesonlsp/archive/v%{version}/%{name}-%{version}.tar.gz
 
-Requires:       curl
-Requires:       libarchive
 Requires:       patch
 Requires:       git
 Requires:       mercurial
 Requires:       subversion
-Requires:       libpkgconf
-Requires:       libuuid
 BuildRequires:  meson
 BuildRequires:  ninja-build
 BuildRequires:  gcc
 BuildRequires:  g++
 BuildRequires:  git
-BuildRequires:  python3-pip
-BuildRequires:  libcurl-devel
-BuildRequires:  google-benchmark-devel
-BuildRequires:  libarchive-devel
-BuildRequires:  gtest
-BuildRequires:  gtest-devel
-BuildRequires:  libpkgconf-devel
-BuildRequires:  libuuid-devel
-BuildRequires:  uuid
-BuildRequires:  pkgconf-pkg-config
+BuildRequires:  pkgconfig(benchmark)
+BuildRequires:  pkgconfig(gtest)
+BuildRequires:  pkgconfig(libarchive)
+BuildRequires:  pkgconfig(libcurl)
+BuildRequires:  pkgconfig(libpkgconf)
+BuildRequires:  pkgconfig(nlohmann_json)
+BuildRequires:  pkgconfig(uuid)
+BuildRequires:  python3dist(lsprotocol)
+BuildRequires:  python3dist(pygls)
 
 %description
 A meson language server

--- a/mesonlsp.spec
+++ b/mesonlsp.spec
@@ -1,6 +1,4 @@
-%global debug_package %{nil}
 %global __meson_wrap_mode default
-%undefine _auto_set_build_flags
 
 Name:           mesonlsp
 Version:        4.1.3
@@ -42,7 +40,7 @@ A meson language server
 %autosetup
 
 %build
-%meson --buildtype release 
+%meson
 %meson_build
 
 %install

--- a/mesonlsp.spec
+++ b/mesonlsp.spec
@@ -9,7 +9,7 @@ Summary:        Meson language server
 ExclusiveArch:  x86_64
 
 License:        GPL-3.0-or-later
-Source0:        https://github.com/JCWasmx86/Swift-MesonLSP/archive/refs/tags/v%{version}.tar.gz
+Source0:        https://github.com/JCWasmx86/mesonlsp/archive/v%{version}/%{name}-%{version}.tar.gz
 
 Requires:       curl
 Requires:       libarchive
@@ -39,15 +39,13 @@ BuildRequires:  pkgconf-pkg-config
 A meson language server
 
 %prep
-%autosetup -c
+%autosetup
 
 %build
-cd mesonlsp-%{version}
 %meson --buildtype release 
 %meson_build
 
 %install
-cd mesonlsp-%{version}
 %meson_install
 
 %files


### PR DESCRIPTION
This does assume you are targeting Fedora, but it removes extra work.

1. A different URL allows dropping manual directory changes.
2. Extra runtime requirements are dropped, as they are automatically added for linked libraries.
3. Use some `pkgconfig` based dependencies, which correspond with the requirements directly. Also BuildRequire the needed Python packages.

It is based on #55 and #56.