### PR TITLE
Don't use gtest subproject when tests are disabled

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,7 +153,7 @@ gtest_dep = dependency('gtest', main: true, required: false)
 
 subdir('src')
 
-if not gtest_dep.found()
+if not gtest_dep.found() and get_option('tests')
     gtest_proj = subproject('gtest')
     gtest_dep = gtest_proj.get_variable('gtest_dep')
 endif


### PR DESCRIPTION
This change allows building without downloading the gtest dependency when tests are disabled.

Checklist:
- [ ] Did you update the CHANGELOG?
- [X] If you introduced dependencies: Did you update the `mesonlsp.spec`, `scripts/create_license_file.sh` and *all* GitHub Actions files?
- [X] Did you run a profiler, if you inserted a lot of C++ code, especially in the Lexer, Parser or the Type Analyzer?
