### PR TITLE
Fix subproject base dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Add support for specifying custom subproject_dir (top level directory name that holds Meson subprojects)
 # 4.2.0 (May 03 2024)
 - Add `mesonlint` tool that allows to lint a project and to check+fix the formatting. It's currently not integrated with the language server.
 - Fix a few deprecation informations (#70, by @ptomato)

--- a/src/libanalyze/mesontree.hpp
+++ b/src/libanalyze/mesontree.hpp
@@ -45,6 +45,7 @@ public:
 
   void fullParse(AnalysisOptions analysisOptions, bool downloadSubprojects) {
     if (this->depth < MAX_TREE_DEPTH) {
+      this->parseRootFile();
       this->state.used = true;
       this->state.fullSetup(analysisOptions, depth + 1, this->identifier,
                             this->ns, downloadSubprojects,
@@ -82,6 +83,7 @@ public:
   MesonTree &operator=(const MesonTree &) = delete;
 
 private:
+  std::shared_ptr<Node> parseRootFile();
   OptionState parseFile(const std::filesystem::path &path,
                         MesonMetadata *originalMetadata);
   OptionState parseOptions(const std::filesystem::path &treeRoot,

--- a/src/libanalyze/subprojects/subprojectstate.hpp
+++ b/src/libanalyze/subprojects/subprojectstate.hpp
@@ -20,7 +20,7 @@ public:
   explicit SubprojectState(std::filesystem::path root)
       : root(std::move(root)) {}
 
-  void findSubprojects(bool downloadSubprojects);
+  void findSubprojects(bool downloadSubprojects, MesonTree *tree);
   void initSubprojects();
   void updateSubprojects();
   void parseSubprojects(const AnalysisOptions &options, int depth,
@@ -54,7 +54,7 @@ public:
                  const std::string &parentIdentifier, const TypeNamespace &ns,
                  bool downloadSubprojects, bool useCustomParser,
                  MesonTree *tree) {
-    this->findSubprojects(downloadSubprojects);
+    this->findSubprojects(downloadSubprojects, tree);
     this->initSubprojects();
     this->updateSubprojects();
     this->parseSubprojects(options, depth, parentIdentifier, ns,


### PR DESCRIPTION
Add support for specifying custom subproject_dir (top level directory name that holds Meson subprojects)

Checklist:
- [x] Did you update the CHANGELOG?
- [x] If you introduced dependencies: Did you update the `mesonlsp.spec`, `scripts/create_license_file.sh` and *all* GitHub Actions files?
- [x] Did you run a profiler, if you inserted a lot of C++ code, especially in the Lexer, Parser or the Type Analyzer?