### PR TITLE
a few type fixes (#172)

### DIFF
--- a/src/libtypenamespace/addedData.csv
+++ b/src/libtypenamespace/addedData.csv
@@ -119,3 +119,4 @@ sourceset_module::source_set,0.51.0
 wayland_module::find_protocol,0.62.0
 wayland_module::scan_xml,0.62.0
 env::unset,1.4.0
+build_machine::kernel,1.2.0

--- a/src/libtypenamespace/functions.def
+++ b/src/libtypenamespace/functions.def
@@ -3545,7 +3545,7 @@ subdir:
     - @if_found:
       - Optional: true
       - Types:
-        - list(dep)
+        - list(dep|external_program)
   - returns:
 subdir_done:
   - args:

--- a/src/libtypenamespace/methoddocs.def
+++ b/src/libtypenamespace/methoddocs.def
@@ -13,6 +13,8 @@ Returns a more specific CPU name, such as `i686`, `amd64`, etc.
 Returns the CPU family name. [This table](https://mesonbuild.com/Reference-tables.html#cpu-families) contains all known CPU families. These are guaranteed to continue working.
 @build_machine::endian:
 Returns `'big'` on big-endian systems and `'little'` on little-endian systems.
+@build_machine::kernel:
+Returns the native kernel name. [This table](https://mesonbuild.com/Reference-tables.html#kernel-names-since-120) lists all of the currently known Kernel names.
 @build_machine::system:
 Returns the operating system name. [This table](https://mesonbuild.com/Reference-tables.html#operating-system-names) lists all of the currently known Operating System names, these are guaranteed to continue working.
 @build_tgt::extract_all_objects:

--- a/src/libtypenamespace/methods.def
+++ b/src/libtypenamespace/methods.def
@@ -36,6 +36,10 @@ build_machine::endian:
   - args:
   - returns:
     - str
+build_machine::kernel:
+  - args:
+  - returns:
+    - str
 build_machine::system:
   - args:
   - returns:
@@ -1917,6 +1921,7 @@ generator::process:
         - custom_tgt
         - custom_idx
         - generated_list
+        - exe
     - @env:
       - Optional: true
       - Types:


### PR DESCRIPTION
- `subdir(if_found: )` now accepts `external_program`
- added `build_machine::kernel` and docs
- `generator::process` now accepts `exe`

Checklist:
- [ ] Did you update the CHANGELOG?
- ~~[ ] If you introduced dependencies: Did you update the `mesonlsp.spec`, `scripts/create_license_file.sh` and *all* GitHub Actions files?~~
- ~~[ ] Did you run a profiler, if you inserted a lot of C++ code, especially in the Lexer, Parser or the Type Analyzer?~~

Fixes #172
