### PR TITLE
fix(liblangserver): Avoid stderr deadlock during initPkgNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 5.0.2 (Apr 27 2026)
+- Fix server hanging in `initialize` on systems with many pkg-config packages
 # 5.0.1 (Apr 27 2026)
 - Fix crash on startup (#192)
 # 5.0.0 (Apr 25 2026)

--- a/src/liblangserver/langserver.cpp
+++ b/src/liblangserver/langserver.cpp
@@ -142,7 +142,6 @@ void LanguageServer::initPkgNames() {
     auto state = 0;
     for (const auto chr : sout) {
       if (chr == '\n') {
-        LOG.info("Found package: " + pkgName);
         this->descriptions[pkgName] = pkgDescription;
         pkgNames.insert(pkgName);
         pkgName = "";
@@ -169,6 +168,8 @@ void LanguageServer::initPkgNames() {
         pkgDescription.push_back(chr);
       }
     }
+    LOG.info(std::format("Found {} packages",
+                         this->pkgNames.size()));
     return;
   }
   auto *personality = pkgconf_cross_personality_default();
@@ -197,9 +198,7 @@ void LanguageServer::initPkgNames() {
         }
         std::string const pkgName{entry->id};
 
-        if (((LanguageServer *)data)->pkgNames.insert(pkgName).second) {
-          LOG.info("Found package: " + pkgName);
-        }
+        ((LanguageServer *)data)->pkgNames.insert(pkgName);
         if (entry->description) {
           std::string const pkgDescription{entry->description};
           ((LanguageServer *)data)->descriptions[pkgName] = pkgDescription;
@@ -208,6 +207,8 @@ void LanguageServer::initPkgNames() {
       });
   pkgconf_cross_personality_deinit(personality);
   pkgconf_client_deinit(&pkgClient);
+  LOG.info(std::format("Found {} packages",
+                         this->pkgNames.size()));
 }
 
 void LanguageServer::onDidChangeConfiguration(


### PR DESCRIPTION
The LSP test client (pygls) starts the server with stderr=asyncio.subprocess.PIPE and never drains the pipe. On systems with several thousand pkg-config packages, the per-package LOG.info("Found package: ...") calls in initPkgNames write enough to fill Linux's ~64 KiB pipe buffer before initialize() returns. The server then blocks on stderr inside the LSP request handler and never sends the initialize response, so LSPTests/test.py times out at 30 s.

Drop the per-package INFO line in both pkg-config code paths and emit a single summary line instead. Package names are still tracked in pkgNames for completion.

Checklist:
- [x] Did you update the CHANGELOG?
- [ ] If you introduced dependencies: Did you update the `mesonlsp.spec`, `scripts/create_license_file.sh` and *all* GitHub Actions files?
- [ ] Did you run a profiler, if you inserted a lot of C++ code, especially in the Lexer, Parser or the Type Analyzer?
