### PR TITLE
typeanalyzer: skip dead branches for static fs.* path conditions

### DIFF
--- a/src/libanalyze/typeanalyzer/typeanalyzer.cpp
+++ b/src/libanalyze/typeanalyzer/typeanalyzer.cpp
@@ -2476,23 +2476,128 @@ const Version &TypeAnalyzer::matchingVersion() const {
   return this->versionStack.back();
 }
 
+std::optional<bool> TypeAnalyzer::tryEvaluateStaticBoolCondition(
+    const Node *node, const std::filesystem::path &mesonDir) const {
+  // Only evaluate a narrow class of conditions (filesystem facts on string
+  // literals). Plain `true`/`false`/`1 == 1` intentionally stay unknown so
+  // type merging still considers all branches unless a branch is ruled out by
+  // fs.{is_dir,exists,...}(literal).
+  using enum BinaryOperator;
+  using enum NodeType;
+  using enum UnaryOperator;
+  switch (node->type) {
+  case UNARY_EXPRESSION: {
+    const auto *unary = static_cast<const UnaryExpression *>(node);
+    if (unary->op != NOT && unary->op != EXCLAMATION_MARK) {
+      return std::nullopt;
+    }
+    auto inner = this->tryEvaluateStaticBoolCondition(
+        unary->expression.get(), mesonDir);
+    if (!inner.has_value()) {
+      return std::nullopt;
+    }
+    return !inner.value();
+  }
+  case BINARY_EXPRESSION: {
+    const auto *be = static_cast<const BinaryExpression *>(node);
+    auto lhs = this->tryEvaluateStaticBoolCondition(be->lhs.get(), mesonDir);
+    auto rhs = this->tryEvaluateStaticBoolCondition(be->rhs.get(), mesonDir);
+    switch (be->op) {
+    case AND:
+      if (lhs == false || rhs == false) {
+        return false;
+      }
+      if (lhs == true && rhs == true) {
+        return true;
+      }
+      return std::nullopt;
+    case OR:
+      if (lhs == true || rhs == true) {
+        return true;
+      }
+      if (lhs == false && rhs == false) {
+        return false;
+      }
+      return std::nullopt;
+    default:
+      return std::nullopt;
+    }
+  }
+  case METHOD_EXPRESSION: {
+    const auto *me = static_cast<const MethodExpression *>(node);
+    if (me->method == nullptr || me->args == nullptr ||
+        me->args->type != ARGUMENT_LIST) {
+      return std::nullopt;
+    }
+    const auto *al = static_cast<const ArgumentList *>(me->args.get());
+    const Node *firstPositional = nullptr;
+    for (const auto &argNode : al->args) {
+      if (argNode->type != KEYWORD_ITEM) {
+        firstPositional = argNode.get();
+        break;
+      }
+    }
+    if (firstPositional == nullptr) {
+      return std::nullopt;
+    }
+    const auto *sl = dynamic_cast<const StringLiteral *>(firstPositional);
+    if (sl == nullptr) {
+      return std::nullopt;
+    }
+    std::filesystem::path path(sl->id);
+    if (!path.is_absolute()) {
+      path = mesonDir / path;
+    }
+    std::error_code errc;
+    const std::string &mid = me->method->id();
+    if (mid == "fs_module.is_dir") {
+      return std::filesystem::is_directory(path, errc);
+    }
+    if (mid == "fs_module.exists") {
+      return std::filesystem::exists(path, errc);
+    }
+    if (mid == "fs_module.is_file") {
+      return std::filesystem::is_regular_file(path, errc);
+    }
+    if (mid == "fs_module.is_symlink") {
+      return std::filesystem::is_symlink(path, errc);
+    }
+    return std::nullopt;
+  }
+  default:
+    return std::nullopt;
+  }
+}
+
 void TypeAnalyzer::visitSelectionStatement(SelectionStatement *node) {
   this->stack.emplace_back();
   this->overriddenVariables.emplace_back();
   this->selectionStatementStack.emplace_back();
   auto idx = 0UL;
   std::vector<IdExpression *> allLeft;
+  bool skipRestAfterProvablyTrue = false;
   for (const auto &block : node->blocks) {
+    if (skipRestAfterProvablyTrue) {
+      break;
+    }
     auto appended = false;
     auto appendedVersion = false;
+    std::optional<bool> staticTruth;
     if (idx < node->conditions.size()) {
       const auto &cond = node->conditions[idx];
       cond->visit(this);
+      staticTruth = this->tryEvaluateStaticBoolCondition(
+          cond.get(),
+          cond->file->file.parent_path());
       appended = this->checkCondition(cond.get());
       appendedVersion = this->checkConditionForVersionComparison(cond.get());
     }
+    const bool skipBlockBody =
+        staticTruth.has_value() && !staticTruth.value();
     this->variablesNeedingUse.emplace_back();
-    this->visitChildren(block);
+    if (!skipBlockBody) {
+      this->visitChildren(block);
+    }
     if (appended) {
       this->ignoreUnknownIdentifier.pop_back();
     }
@@ -2503,6 +2608,9 @@ void TypeAnalyzer::visitSelectionStatement(SelectionStatement *node) {
     allLeft.insert(allLeft.end(), lastNeedingUse.begin(), lastNeedingUse.end());
     this->variablesNeedingUse.pop_back();
     idx++;
+    if (staticTruth == true) {
+      skipRestAfterProvablyTrue = true;
+    }
   }
   std::set<std::string> dedupedUnusedAssignments;
   auto toInsert = this->variablesNeedingUse.back();

--- a/src/libanalyze/typeanalyzer/typeanalyzer.hpp
+++ b/src/libanalyze/typeanalyzer/typeanalyzer.hpp
@@ -182,4 +182,7 @@ private:
   bool checkConditionForVersionComparison(const Node *condition);
   void pushVersion(const std::string &version);
   const Version &matchingVersion() const;
+  std::optional<bool>
+  tryEvaluateStaticBoolCondition(const Node *node,
+                                 const std::filesystem::path &mesonDir) const;
 };

--- a/tests/integration/meson.build
+++ b/tests/integration/meson.build
@@ -278,6 +278,12 @@ type_analyzer_tests = [
         ],
     ],
     [
+        'fs_static_if',
+        [
+            ['after_false_if', 'str'],
+        ],
+    ],
+    [
         'assignment',
         [
             ['someint', 'int'],

--- a/tests/integration/type-analyzer-test/fs_static_if.meson
+++ b/tests/integration/type-analyzer-test/fs_static_if.meson
@@ -1,0 +1,6 @@
+fs = import('fs')
+# Branch is provably false → inner assignment must not affect analysis
+after_false_if = 'outer'
+if fs.is_dir('__mesonlsp_fs_static_branch_absent__')
+  after_false_if = 1
+endif


### PR DESCRIPTION
Problem
- When meson.build uses guards such as `if fs.is_dir('optional_sub') ...`,
  the type analyzer still walked every branch, so `subdir()` and other calls
  inside provably_unreachable blocks were still type-checked (false positives
  on optional directories, extra work).

Approach
- After visiting each `if`/`elif` condition, evaluate a narrow static
  boolean when the expression is built only from `not`, `and`, `or`, and
  (`fs_module` method calls with a string literal path).
- Paths are resolved relative to the current meson file, matching Meson’s fs
  module rules; `is_directory`, `exists`, `is_regular_file`, and
  `is_symlink` use `std::filesystem` with `error_code` (no exceptions).
- If the condition is provably false, the body is not visited (no semantic
  checks or `subdir` recursion for that block).
- If the condition is provably true, subsequent `elif`/`else` blocks are
  skipped for analysis (aligned with runtime short-circuiting).

Intentional limits
- Plain `true`/`false` literals and integer/string `==` are not folded,
  so existing tests that merge types across all syntactic branches (e.g.
  `selectionstatement.meson`) keep the same behaviour.

Tests
- Add `tests/integration/type-analyzer-test/fs_static_if.meson` and
  register `ta-fs_static_if`: variable type stays `str` when the only
  `int` assignment sits in a branch guarded by `fs.is_dir` on a missing
  path.

